### PR TITLE
bump: release v0.2.0-beta

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -2,6 +2,7 @@
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "semver"
-version_provider = "pep621"
+version_provider = "commitizen"
+version = "0.2.0b0"
 update_changelog_on_bump = true
 major_version_zero = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://www.conventionalcommits.org/) for commit guidelines.
+
+## v0.2.0-beta (2026-02-18)
+
+### Feat
+
+- add AWS Lambda deployment support via SAM
+
+### Fix
+
+- **deps**: bump cryptography 46.0.4 → 46.0.5 (CVE-2026-26007)
+- improve error handling across frontend and backend
+- Mangum stage path stripping + Lambda logging
+- Lambda crash on cors_origins parsing + add request logging
+- address Copilot review wave 2 feedback
+- address Copilot review feedback on Lambda deployment PR
+- resolve sam build failures (runtime, deps, container build)
+- resolve CORS wildcard error and add Lambda best practices
+- align pre-commit tool versions with CI by using local hooks
+
+### Docs
+
+- reorganize documentation into 11 numbered sections (44 files)
+- standardize all cross-reference sections to Related Docs tables
+- create docs/README.md entry point and update root README links
+- deduplicate security policy (docs version now points to root SECURITY.md)
+- update documentation for AWS Lambda deployment architecture
+
+### Refactor
+
+- apply poetry-lock and code formatting
+- use pytest fixture for TestClient instead of module-level instance
+
+## v0.1.0-beta (2026-02-06)
+
+### BREAKING CHANGE
+
+- Replace PowerShell-specific commands with cross-platform solutions
+
+### Feat
+
+- initial commit — morning routine productivity tracker
+
+### Fix
+
+- make pre-commit hooks cross-platform compatible
+- **security**: update protobuf to 6.33.5 (CVE-2026-0994)
+- **frontend**: handle missing Supabase env vars during build
+- **frontend**: update ESLint to native flat config
+- wrap useSearchParams in Suspense boundary for static generation
+- resolve TypeScript and Ruff formatting errors
+- **frontend**: resolve ESLint and gitignore issues
+- fixed username at CI of readme.md

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,7 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 0.2.x   | :white_check_mark: |
 | 0.1.x   | :white_check_mark: |
 | < 0.1   | :x:                |
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "morning-routine-backend"
-version = "0.1.0"
+version = "0.2.0b0"
 description = "FastAPI backend for Morning Routine & Productivity Tracker"
 authors = ["Rafael Jyo Kondo <rafaeljkey@gmail.com>"]
 package-mode = false

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-routine-frontend",
-  "version": "0.1.0",
+  "version": "0.2.0-beta",
   "private": true,
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
## Release v0.2.0-beta

### What changed since v0.1.0-beta

#### Features
- **AWS Lambda deployment** via SAM (`feat/aws-lambda-deployment`)

#### Bug Fixes
- `cryptography` 46.0.4 → 46.0.5 (CVE-2026-26007)
- CORS origins parsing crash on Lambda
- Mangum stage path stripping + Lambda logging
- Error handling improvements across frontend and backend
- Pre-commit hook cross-platform alignment with CI

#### Documentation
- Full reorganization into 11 numbered sections (44 files)
- Standardized "Related Docs" tables across all docs
- Created `docs/README.md` entry point
- Deduplicated security policy (docs → root `SECURITY.md`)

#### Refactor
- Poetry lock + code formatting cleanup
- Pytest fixtures instead of module-level TestClient

### Release checklist
- [x] CHANGELOG.md created with full history
- [x] Version bumped in `.cz.toml`, `backend/pyproject.toml`, `frontend/package.json`
- [x] SECURITY.md supported versions updated
- [x] All pre-commit hooks pass
- [x] CI passes
- [ ] Merge to main
- [ ] Tag `v0.2.0-beta` on the merge commit
- [ ] Create GitHub Release from tag