### PR TITLE
refactor: migrate Pydantic class Config to model_config = ConfigDict(...)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 import json
 from functools import lru_cache
 
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -45,11 +45,12 @@ class Settings(BaseSettings):
                 pass
         return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
 
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        # In Lambda, env vars are set directly; .env file won't exist and that's fine
-        extra = "ignore"
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        # In Lambda, env vars are set directly; .env file won't exist and that's fine.
+        extra="ignore",
+    )
 
 
 @lru_cache(128)

--- a/backend/app/models/productivity.py
+++ b/backend/app/models/productivity.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ProductivityBase(BaseModel):
@@ -40,10 +40,9 @@ class ProductivityUpdate(BaseModel):
 class Productivity(ProductivityBase):
     """Full productivity model with database fields."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     user_id: str
     created_at: datetime
     updated_at: datetime
-
-    class Config:
-        from_attributes = True

--- a/backend/app/models/routine.py
+++ b/backend/app/models/routine.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class MorningRoutineBase(BaseModel):
@@ -42,10 +42,9 @@ class MorningRoutineUpdate(BaseModel):
 class MorningRoutine(MorningRoutineBase):
     """Full morning routine model with database fields."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     user_id: str
     created_at: datetime
     updated_at: datetime
-
-    class Config:
-        from_attributes = True

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, time
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 # ============================================
@@ -47,6 +47,8 @@ class UserProfileUpdate(BaseModel):
 class UserProfile(UserProfileBase):
     """Full user profile model with all fields."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     email: str
     is_active: bool = True
@@ -55,9 +57,6 @@ class UserProfile(UserProfileBase):
     created_at: datetime
     updated_at: datetime
     last_login_at: datetime | None = None
-
-    class Config:
-        from_attributes = True
 
 
 # ============================================
@@ -130,13 +129,12 @@ class UserSettingsUpdate(BaseModel):
 class UserSettings(UserSettingsBase):
     """Full user settings model with all fields."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     user_id: str
     created_at: datetime
     updated_at: datetime
-
-    class Config:
-        from_attributes = True
 
 
 # ============================================
@@ -186,13 +184,12 @@ class UserGoalUpdate(BaseModel):
 class UserGoal(UserGoalBase):
     """Full goal model with all fields."""
 
+    model_config = ConfigDict(from_attributes=True)
+
     id: str
     user_id: str
     created_at: datetime
     updated_at: datetime
-
-    class Config:
-        from_attributes = True
 
 
 # ============================================


### PR DESCRIPTION
## Summary

Migrate all Pydantic `class Config` inner classes to the modern `model_config = ConfigDict(...)` pattern.

### Why

Pydantic V2 deprecated class-based `Config` in favor of `model_config = ConfigDict(...)`. The old style triggers `PydanticDeprecatedSince20` warnings and will be removed in Pydantic V3.

### Changes

| File | Class | Migration |
|------|-------|-----------|
| `app/core/config.py` | `Settings` | `class Config` → `model_config = SettingsConfigDict(...)` |
| `app/models/productivity.py` | `Productivity` | `class Config` → `model_config = ConfigDict(from_attributes=True)` |
| `app/models/routine.py` | `MorningRoutine` | `class Config` → `model_config = ConfigDict(from_attributes=True)` |
| `app/models/user.py` | `UserProfile`, `UserSettings`, `UserGoal` | `class Config` → `model_config = ConfigDict(from_attributes=True)` |

### Result

- **Before**: 98 passed, 18 warnings
- **After**: 98 passed, 12 warnings (remaining 12 are from `pyiceberg`, third-party)

Ref: https://docs.pydantic.dev/2.12/migration/